### PR TITLE
Fix login not working

### DIFF
--- a/middleware/logged-out.js
+++ b/middleware/logged-out.js
@@ -2,7 +2,7 @@ import { parse } from 'cookieparser'
 
 export default ({ store, redirect, req }) => {
     if(!req) return
-    if(typeof req.headers.cookie !== 'string') return redirect('/')
+    if(typeof req.headers.cookie !== 'string') return
 
     const cookies = parse(req.headers.cookie)
     if(cookies.token)


### PR DESCRIPTION
The issue was caused due to it redirecting to the main page when it had no cookies - which, if we're new and haven't logged in, was a problem - causing us to not be able to logged in, unless there was something creating a cookie before (Cloudflare proxy etc.)

This was discussed all along on the Cryb Discord server.