### PR TITLE
Add support for branding config

### DIFF
--- a/brand/config.js
+++ b/brand/config.js
@@ -1,0 +1,3 @@
+export default {
+	name: 'Cryb'
+}

--- a/brand/config.js
+++ b/brand/config.js
@@ -2,5 +2,5 @@ export default {
 	// The name of the service (i.e. 'Cryb')
 	name: 'Cryb',
 	// The YouTube ID for the landing video
-	landing_video_id: ''
+	landing_video_id: '-eUJgIrWONo'
 }

--- a/brand/config.js
+++ b/brand/config.js
@@ -1,3 +1,9 @@
+/**
+ * Note that you'll still need to change the logo, which is located under static/img.
+ * We recommend that you keep the cryb_ prefix for these files to avoid any conflicts.
+ * The cryb_ prefix won't be visible to users, and we'll remove any cryb- or cryb_ prefixes in static files in the future.
+ */
+
 export default {
 	// The name of the service (i.e. 'Cryb')
 	name: 'Cryb',

--- a/brand/config.js
+++ b/brand/config.js
@@ -1,3 +1,6 @@
 export default {
-	name: 'Cryb'
+	// The name of the service (i.e. 'Cryb')
+	name: 'Cryb',
+	// The YouTube ID for the landing video
+	landing_video_id: ''
 }

--- a/components/player/viewer.vue
+++ b/components/player/viewer.vue
@@ -9,7 +9,7 @@
         <div class="player-tooltips" v-if=showMutedPopup>
             <div class="player-tooltip" :class="{ visible: showMutedPopup }">
                 <div class="player-tooltip-info">
-                    <p class="player-tooltip-title">Cryb is muted</p>
+                    <p class="player-tooltip-title">{{ brand.name }} is muted</p>
                     <p class="player-tooltip-body">Your browser requires user interaction in order to let us play video with audio</p>
                 </div>
                 <Button @click.native=unmute()>Unmute</Button>
@@ -19,6 +19,8 @@
 </template>
 <script>
     import { mapGetters } from 'vuex'
+    
+    import brand from '~/brand/config'
 
     import Button from '~/components/button'
 
@@ -43,6 +45,7 @@
         },
         data() {
             return {
+                ...brand,
                 activeKeyEvent: null,
                 showMutedPopup: false
             }

--- a/components/player/viewer.vue
+++ b/components/player/viewer.vue
@@ -45,7 +45,7 @@
         },
         data() {
             return {
-                ...brand,
+                brand,
                 activeKeyEvent: null,
                 showMutedPopup: false
             }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -43,7 +43,7 @@
         },
         data() {
             return {
-                ...brand
+                brand
             }
         },
         components: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -10,16 +10,18 @@
     import { mapGetters } from 'vuex'
     import { parse } from 'cookieparser'
     
+    import brand from '~/brand/config'
+
     import Header from '~/components/header/index'
 
     export default {
         head() {
             return {
-                titleTemplate: chunk => this.$route.name === 'room' && this.room ? `${this.room.name} - Cryb` : (chunk ? `${chunk} - Cryb` : 'Cryb'),
+                titleTemplate: chunk => this.$route.name === 'room' && this.room ? `${this.room.name} - ${this.brand.name}` : (chunk ? `${chunk} - ${this.brand.name}` : this.brand.name),
                 meta: [
                     { charset: 'utf-8' },
                     { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-                    { name: 'description', content: 'Cryb makes it easy to enjoy what you love with your friends' },
+                    { name: 'description', content: `${this.brand.name} makes it easy to enjoy what you love with your friends` },
                     { name: 'theme-color', content: '#000000' },
                     { property: 'og:image', content: '/img/cryb-icon-hq.png'}
                 ],
@@ -37,6 +39,11 @@
             ...mapGetters(['room']),
             isDarkTheme() {
                 return this.$route.name === 'room'
+            }
+        },
+        data() {
+            return {
+                ...brand
             }
         },
         components: {

--- a/layouts/logged-out.vue
+++ b/layouts/logged-out.vue
@@ -4,14 +4,16 @@
     </div>
 </template>
 <script>
+    import brand from '~/brand/config'
+
     export default {
         head() {
             return {
-                titleTemplate: 'Cryb',
+                titleTemplate: this.brand.name,
                 meta: [
                     { charset: 'utf-8' },
                     { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-                    { name: 'description', content: 'Cryb makes it easy to enjoy what you love with your friends' }
+                    { name: 'description', content: `${this.brand.name} makes it easy to enjoy what you love with your friends` }
                 ],
                 link: [
                     { rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }
@@ -21,6 +23,11 @@
                         src: 'https://www.googletagmanager.com/gtag/js?id=UA-146441740-1'
                     }
                 ]
+            }
+        },
+        data() {
+            return {
+                ...brand
             }
         }
     }

--- a/layouts/logged-out.vue
+++ b/layouts/logged-out.vue
@@ -27,7 +27,7 @@
         },
         data() {
             return {
-                ...brand
+                brand
             }
         }
     }

--- a/pages/i/_id.vue
+++ b/pages/i/_id.vue
@@ -34,6 +34,8 @@
 <script>
     import { mapGetters } from 'vuex'
 
+    import brand from '~/brand/config'
+
     import Form from '~/components/form'
     import Button from '~/components/button'
 
@@ -55,10 +57,10 @@
             if(this.room)
                 inviteHeaders = {
                     meta: [
-                        { name: 'description', content: `You've been invted to join ${this.membersList} on Cryb, the best way to share the internet with your friends` },
+                        { name: 'description', content: `You've been invted to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
 
-                        { property: 'og:title', content: `Join ${this.room.name} on Cryb` },
-                        { property: 'og:description', content: `You've been invted to join ${this.membersList} on Cryb, the best way to share the internet with your friends` },
+                        { property: 'og:title', content: `Join ${this.room.name} on ${this.brand.name}` },
+                        { property: 'og:description', content: `You've been invted to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
                     ],
                     link: [
                         { rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }
@@ -92,6 +94,7 @@
         },
         data() {
             return {
+                ...brand,
                 error: '',
                 loading: false
             }

--- a/pages/i/_id.vue
+++ b/pages/i/_id.vue
@@ -94,7 +94,7 @@
         },
         data() {
             return {
-                ...brand,
+                brand,
                 error: '',
                 loading: false
             }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,6 +16,7 @@
             </div>
         </div>
         <div class="right">
+            <iframe class="video" width="1920" height="1080" :src="`https://www.youtube.com/embed/${brand.landing_video_id}?controls=0&autoplay=1&loop=1&playlist=${brand.landing_video_id}`" frameborder="0" allow="accelerometer; autoplay; loop; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
             <iframe class="video" width="1920" height="1080" src="https://www.youtube.com/embed/-eUJgIrWONo?controls=0&autoplay=1&loop=1&playlist=-eUJgIrWONo" frameborder="0" allow="accelerometer; autoplay; loop; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,6 @@
         </div>
         <div class="right">
             <iframe class="video" width="1920" height="1080" :src="`https://www.youtube.com/embed/${brand.landing_video_id}?controls=0&autoplay=1&loop=1&playlist=${brand.landing_video_id}`" frameborder="0" allow="accelerometer; autoplay; loop; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-            <iframe class="video" width="1920" height="1080" src="https://www.youtube.com/embed/-eUJgIrWONo?controls=0&autoplay=1&loop=1&playlist=-eUJgIrWONo" frameborder="0" allow="accelerometer; autoplay; loop; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,7 +40,7 @@
         middleware: 'logged-out',
         data() {
             return {
-                ...brand
+                brand
             }
         },
         components: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,14 +4,14 @@
             <div class="center">
                 <img src="/img/cryb-logo.svg" class="logo">
                 <h1 class="title">Share the internet with your friends</h1>
-                <p class="body">Cryb makes it easy to start up a room, add your friends, and browse the web</p>
+                <p class="body">{{ brand.name }} makes it easy to start up a room, add your friends, and browse the web</p>
                 <div class="login" v-if=!token>
                     <Button type="discord" :href=redirectUrl icon="/icons/discord-white.svg" hover="/icons/discord-colour.svg">
                         Login with Discord
                     </Button>
                 </div>
                 <div class="continue" v-else>
-                    <Button href="/home" icon="/icons/user-white.svg" hover="/icons/user.svg">Continue to Cryb</Button>
+                    <Button href="/home" icon="/icons/user-white.svg" hover="/icons/user.svg">Continue to {{ brand.name }}</Button>
                 </div>
             </div>
         </div>
@@ -22,6 +22,8 @@
 </template>
 <script>
     import { mapGetters } from 'vuex'
+    
+    import brand from '~/brand/config'
 
     import Button from '~/components/button'
 
@@ -36,6 +38,11 @@
         },
         layout: 'logged-out',
         middleware: 'logged-out',
+        data() {
+            return {
+                ...brand
+            }
+        },
         components: {
             Button
         }


### PR DESCRIPTION
This PR will add support for effortlessly changing the branding of Cryb, such as the name and landing video.

Changes can be made in `brand/config.js` in a JSON format.