### PR TITLE
avatar circle: change 9999px to 50%

### DIFF
--- a/static/css/invite.css
+++ b/static/css/invite.css
@@ -15,7 +15,7 @@ div.invite-details {
 img.invite-member-icon {
     height: 35px;
 
-    border-radius: 999px;
+    border-radius: 50%;
 
     margin: auto
 }

--- a/static/css/master.css
+++ b/static/css/master.css
@@ -110,7 +110,7 @@ div.header div.gradient:hover + img.logo {
 
 div.header img.profile-image {
     cursor: pointer;
-    border-radius: 9999px;
+    border-radius: 50%;
     width: 32px;
     height: 32px;
     background-color: rgba(112, 128, 144, 0.25);

--- a/static/css/room/chat.css
+++ b/static/css/room/chat.css
@@ -40,7 +40,7 @@ div.chat-messages div.grouped-chat-wrapper {
 }
 
 div.grouped-chat-wrapper img.chat-author-avatar {
-    border-radius: 9999px;
+    border-radius: 50%;
     
     height: 50px;
     width: 50px;

--- a/static/css/room/footer.css
+++ b/static/css/room/footer.css
@@ -32,7 +32,7 @@ div.user-icons div.user-icon {
     height: 100px;
     width: 100px;
     margin-left: 1.5em;
-    border-radius: 999px;
+    border-radius: 50%;
     background-color: rgba(112, 128, 144, 0.25);
 }
 
@@ -62,7 +62,7 @@ div.user-icons div.user-icon.passable:hover {
 }
 
 div.user-icon img.user-icon-avatar {
-    border-radius: 100px;
+    border-radius: 50%;
     height: 100%
 }
 
@@ -83,7 +83,7 @@ div.user-icon div.user-control-indicator {
     bottom: 2.15em;
 
     margin-left: 60px;
-    border-radius: 999px;
+    border-radius: 50%;
 
     background-color: white;
     box-shadow: 0 0 0px 6px black;

--- a/static/css/room/user-icon.css
+++ b/static/css/room/user-icon.css
@@ -12,7 +12,7 @@ div.user-icon div.user-name-wrapper {
 
     font-weight: bold;
     text-align: center;
-    border-radius: 999px;
+    border-radius: 50%;
 
     transition: all 0.2s;
 }


### PR DESCRIPTION
This basically does the same but using 50% is a better solution. There are also some cases where the image isn't a circle anymore. This should fix that issue. Also, using percentages is recommended because it's better for scaling with something like mobile devices or small windows.