### PR TITLE
Fix user name shape

### DIFF
--- a/static/css/room/user-icon.css
+++ b/static/css/room/user-icon.css
@@ -12,7 +12,7 @@ div.user-icon div.user-name-wrapper {
 
     font-weight: bold;
     text-align: center;
-    border-radius: 50%;
+    border-radius: 50px;
 
     transition: all 0.2s;
 }


### PR DESCRIPTION
I accidently changed this to 50%. This PR fixes that. Note: long user names still cut off. I'll look into that later.