### PR TITLE
Mobile UI support for Rooms

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -29,7 +29,7 @@
                 titleTemplate: chunk => this.$route.name === 'room' && this.room ? `${this.room.name} - ${this.brand.name}` : (chunk ? `${chunk} - ${this.brand.name}` : this.brand.name),
                 meta: [
                     { charset: 'utf-8' },
-                    { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+                    { name: 'viewport', content: 'width=device-width, initial-scale=1, user-scalable=no' },
                     { name: 'description', content: `${this.brand.name} makes it easy to enjoy what you love with your friends` },
                     { name: 'theme-color', content: '#000000' },
                     { property: 'og:image', content: '/img/icon-hq.png'}

--- a/static/css/room/chat-bar.css
+++ b/static/css/room/chat-bar.css
@@ -72,3 +72,12 @@ div.send-button img.send-button-icon {
 div.chat-bar-wrapper div.send-button.is-enabled img.send-button-icon {
     filter: invert(0)
 }
+
+@media only screen and (max-width: 768px) and (orientation: landscape) {
+
+    div.chat div.chat-bar-wrapper:focus-within {
+        visibility: visible;
+        background: inherit;
+    }
+
+}

--- a/static/css/room/chat.css
+++ b/static/css/room/chat.css
@@ -161,6 +161,17 @@ div.content div.watch div.player-footer, div.content div.watch div.chat {
 
 @media only screen and (max-width: 768px) and (orientation: landscape) {
 
+    div.content div.watch div.chat:focus-within {
+        display:block;
+        visibility: hidden;
+
+        position: fixed;
+        top: 0px;
+        bottom: 0px;
+
+        width: 100%;
+    }
+
     div.content div.watch div.chat {
         display:none;
     }

--- a/static/css/room/chat.css
+++ b/static/css/room/chat.css
@@ -149,7 +149,12 @@ div.content div.watch div.player-footer, div.content div.watch div.chat {
     div.content div.watch div.chat {
         left:0;
         width:100%;
-        top:50%;
+
+        position: relative;
+        
+        min-height: calc(55vh - 65px);
+        max-height: calc((91vh - 65px) - 56.25vw);
+        height: calc((36vh - 56.25vw) * 100);
     }
 
 }
@@ -157,7 +162,7 @@ div.content div.watch div.player-footer, div.content div.watch div.chat {
 @media only screen and (max-width: 768px) and (orientation: landscape) {
 
     div.content div.watch div.chat {
-        display:none
+        display:none;
     }
 
 }

--- a/static/css/room/chat.css
+++ b/static/css/room/chat.css
@@ -140,3 +140,24 @@ p.chat-typing-bar {
 div.content div.watch div.player-footer, div.content div.watch div.chat {
     background: black;
 }
+
+
+/* Mobile adaptation */
+
+@media only screen and (max-width: 768px) and (orientation: portrait) {
+
+    div.content div.watch div.chat {
+        left:0;
+        width:100%;
+        top:50%;
+    }
+
+}
+
+@media only screen and (max-width: 768px) and (orientation: landscape) {
+
+    div.content div.watch div.chat {
+        display:none
+    }
+
+}

--- a/static/css/room/footer.css
+++ b/static/css/room/footer.css
@@ -125,16 +125,19 @@ div.user-control-indicator:hover:not(.non-interactable) img.user-control-icon.ha
     height: 0;
 }
 
-/* Mobile adaptation - CHAT */
+/* Mobile UI adaptation */
 
 @media only screen and (max-width: 768px) and (orientation: portrait) {
 
     div.content div.watch div.player-footer {
-        right: 0;
-        bottom: 50%;
+        left:0px;
+        right: 0px;
+        top: 0px;
 
         width: 100%;
-        height: 10%;
+        height: 9vh;
+
+        position:relative;
     }
         
     div.user-icons div.user-icon{
@@ -146,7 +149,7 @@ div.user-control-indicator:hover:not(.non-interactable) img.user-control-icon.ha
         padding: 1vh;
     }
 
-    div.user-icon div.has-control {
+    div.user-icons div.has-control {
         box-shadow: 0px 0px 0px 3px white;
     }
 

--- a/static/css/room/footer.css
+++ b/static/css/room/footer.css
@@ -124,3 +124,42 @@ div.user-control-indicator:hover:not(.non-interactable) img.user-control-icon.ha
     opacity: 0;
     height: 0;
 }
+
+/* Mobile adaptation - CHAT */
+
+@media only screen and (max-width: 768px) and (orientation: portrait) {
+
+    div.content div.watch div.player-footer {
+        right: 0;
+        bottom: 50%;
+
+        width: 100%;
+        height: 10%;
+    }
+        
+    div.user-icons div.user-icon{
+        height:7vh;
+        width:7vh;
+    }
+
+    div.player-footer div.user-icons {
+        padding: 1vh;
+    }
+
+    div.user-icon div.has-control {
+        box-shadow: 0px 0px 0px 3px white;
+    }
+
+    div.user-icon div.user-control-indicator {
+        display:none;
+    }
+
+}
+
+@media only screen and (max-width: 768px) and (orientation: landscape) {
+
+    div.content div.watch div.player-footer {
+        display:none;
+    }
+
+}

--- a/static/css/room/invite-hint.css
+++ b/static/css/room/invite-hint.css
@@ -23,7 +23,7 @@ div.invite-hint a.invite-link:hover {
     opacity: 1
 }
 
-/* Mobile adaptation */
+/* Mobile UI adaptation */
 @media only screen and (max-width: 768px),(orientation: portrait) {
 
     div.invite-hint {

--- a/static/css/room/invite-hint.css
+++ b/static/css/room/invite-hint.css
@@ -22,3 +22,12 @@ div.invite-hint a.invite-link {
 div.invite-hint a.invite-link:hover {
     opacity: 1
 }
+
+/* Mobile adaptation */
+@media only screen and (max-width: 768px),(orientation: portrait) {
+
+    div.invite-hint {
+        display:none; /* Temporary fix, needs better solution */
+    }
+
+}

--- a/static/css/room/player.css
+++ b/static/css/room/player.css
@@ -33,6 +33,8 @@ div.player div.player-msg {
 
     margin: 0;
     transform: translate(-50%, -50%);
+
+    padding:5%;
 }
 
 div.player-msg h1.title {
@@ -159,4 +161,24 @@ div.player-tooltip p.player-tooltip-body {
 
 div.player-tooltip a.player-tooltip-action {
     color: black
+}
+
+/* Mobile adaptation */
+
+@media only screen and (max-width: 768px),(orientation: portrait) {
+
+    div.content div.watch div.player-wrapper {
+        width: 100%;
+        bottom: 60%;
+    }
+    
+}
+
+@media only screen and (max-width: 768px) and (orientation: landscape) {
+
+    div.content div.watch div.player-wrapper {
+        width: 100%;
+        bottom: 0;
+    }
+    
 }

--- a/static/css/room/player.css
+++ b/static/css/room/player.css
@@ -163,13 +163,18 @@ div.player-tooltip a.player-tooltip-action {
     color: black
 }
 
-/* Mobile adaptation */
+/* Mobile UI adaptation */
 
-@media only screen and (max-width: 768px),(orientation: portrait) {
+@media only screen and (max-width: 768px) and (orientation: portrait) {
 
     div.content div.watch div.player-wrapper {
         width: 100%;
         bottom: 60%;
+
+        height: 56.25vw;
+        max-height: 36vh;
+
+        position:relative;
     }
     
 }
@@ -177,8 +182,17 @@ div.player-tooltip a.player-tooltip-action {
 @media only screen and (max-width: 768px) and (orientation: landscape) {
 
     div.content div.watch div.player-wrapper {
-        width: 100%;
+        width: 100vw;
+        height: 100vh;
         bottom: 0;
     }
     
+    div.content {
+        top: 0px;
+    }
+
+    div.header{
+        display:none;
+    }
+
 }

--- a/static/css/room/user-icon.css
+++ b/static/css/room/user-icon.css
@@ -38,3 +38,12 @@ div.chat-bar-wrapper input.disabled {
 div.watch {
     overflow: none
 }
+
+/* Mobile adaptation */
+@media only screen and (max-width: 768px) and (orientation: portrait) {
+
+    div.user-icon div.user-name-wrapper {
+        display:none;
+    }
+
+}

--- a/static/css/room/user-icon.css
+++ b/static/css/room/user-icon.css
@@ -39,7 +39,7 @@ div.watch {
     overflow: none
 }
 
-/* Mobile adaptation */
+/* Mobile UI adaptation */
 @media only screen and (max-width: 768px) and (orientation: portrait) {
 
     div.user-icon div.user-name-wrapper {


### PR DESCRIPTION
Made an update on /room to be adaptable for mobile users. Only .CSS was changed, and won't affect the original style for computer screen.

**Changes made:**

**(PC and mobile)** General changes:

- Added a padding on player msg of 5%, so it won't touch player's border.

**(Mobile or screen < 768px)** For portrait mode:
- Chat will occupy 50% vertically, 10% vertically for user icons, and 40% vertically for player trying to respect 16:9 aspect ratio (porcentage excluding header)
- The active controller icon will have a white border, and icon will be disabled for better viewing.
- Invite hint is disabled temporary. Needs a better solution.
- User icon is dynamic resizeble.
- User names are disabled.

**(Mobile or screen < 768px)** For landscape mode:
- Player will occupy 100% of content screen, disabling chat and user icons while landscape. (porcentage excluding header)
