### PR TITLE
Add basic emoji support using Twemoji

### DIFF
--- a/components/chat/message.vue
+++ b/components/chat/message.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="chat-message" :class="{ 'is-loading': loading || isMessageSending }">
-        <p class="chat-message-content">{{ !isMessageSending ? message.content : message }}</p>
+        <p class="chat-message-content">{{ getEmojifiedMessageContent }}</p>
         <div class="chat-message-options" v-if=!isMessageSending>
             <img class="chat-message-option chat-message-report" src="/icons/message-exclaimation.svg" title="Report message" v-if=!isAuthorSelf @click=report()>
             <img class="chat-message-option chat-message-delete" src="/icons/trash-full.svg" title="Delete message" v-if="isAuthorSelf || isSelfRoomOwner" @click=destroy()>
@@ -10,6 +10,7 @@
 <script>
     import { mapGetters } from 'vuex'
     import { formatDistance } from 'date-fns'
+    import emoji from 'node-emoji'
 
     export default {
         computed: {
@@ -25,6 +26,13 @@
             },
             isMessageSending() {
                 return typeof this.message === 'string'
+            },
+            getEmojifiedMessageContent() {
+                if (typeof this.message === 'string') {
+                    return emoji.emojify(this.message)
+                } else {
+                    return emoji.emojify(this.message.content)
+                }
             }
         },
         data() {

--- a/components/chat/message.vue
+++ b/components/chat/message.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="chat-message" :class="{ 'is-loading': loading || isMessageSending }">
-        <p class="chat-message-content">{{ getEmojifiedMessageContent }}</p>
+        <p class="chat-message-content" v-html="getEmojifiedMessageContent"></p>
         <div class="chat-message-options" v-if=!isMessageSending>
             <img class="chat-message-option chat-message-report" src="/icons/message-exclaimation.svg" title="Report message" v-if=!isAuthorSelf @click=report()>
             <img class="chat-message-option chat-message-delete" src="/icons/trash-full.svg" title="Delete message" v-if="isAuthorSelf || isSelfRoomOwner" @click=destroy()>
@@ -11,6 +11,7 @@
     import { mapGetters } from 'vuex'
     import { formatDistance } from 'date-fns'
     import emoji from 'node-emoji'
+    import twemoji from 'twemoji'
 
     export default {
         computed: {
@@ -29,9 +30,9 @@
             },
             getEmojifiedMessageContent() {
                 if (typeof this.message === 'string') {
-                    return emoji.emojify(this.message)
+                    return twemoji.parse(emoji.emojify(this.message))
                 } else {
-                    return emoji.emojify(this.message.content)
+                    return twemoji.parse(emoji.emojify(this.message.content))
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "node-emoji": "^1.10.0",
     "nuxt": "^2.8.1",
     "nuxt-client-init-module": "^0.1.4",
-    "nuxt-clipboard2": "^0.2.1"
+    "nuxt-clipboard2": "^0.2.1",
+    "twemoji": "^12.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "date-fns": "^2.0.1",
     "dotenv": "^8.0.0",
     "jsmpeg": "^1.0.0",
+    "node-emoji": "^1.10.0",
     "nuxt": "^2.8.1",
     "nuxt-client-init-module": "^0.1.4",
     "nuxt-clipboard2": "^0.2.1"

--- a/static/css/room/chat.css
+++ b/static/css/room/chat.css
@@ -140,3 +140,10 @@ p.chat-typing-bar {
 div.content div.watch div.player-footer, div.content div.watch div.chat {
     background: black;
 }
+
+img.emoji {
+   height: 1em;
+   width: 1em;
+   margin: 0 .05em 0 .1em;
+   vertical-align: -0.1em;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4116,6 +4116,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.toarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
+  integrity sha1-JMS/zWsvuji/0FlNsRedjptlZWE=
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -4457,6 +4462,13 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-emoji@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.10.0.tgz#8886abd25d9c7bb61802a658523d1f8d2a89b2da"
+  integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
+  dependencies:
+    lodash.toarray "^4.4.0"
 
 node-fetch@^2.3.0, node-fetch@^2.6.0:
   version "2.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4000,6 +4000,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-5.0.0.tgz#e6b718f73da420d612823996fdf14a03f6ff6922"
+  integrity sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==
+  dependencies:
+    universalify "^0.1.2"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -6672,6 +6681,21 @@ tty-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=
 
+twemoji-parser@12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-12.1.0.tgz#018fb2a67f4747d9decfbf2bb4372995fc568997"
+  integrity sha512-jaHYltumP/E8nR+YzRrY753j9dEpL3zH8+pDXgf9h/10wHeW/9IIjs6mZ1Z/Syh8rIaOQObev1BAX/AinFmuOg==
+
+twemoji@^12.1.3:
+  version "12.1.3"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-12.1.3.tgz#4bebee358c7c44c4278d2badf320bc9e1d057f1d"
+  integrity sha512-Y5mC7vVovHZvCzdXDepJaU6FHPd7PaW6ZTBMWy9sGYafLBn1x0h2T6aGA3cpnz3WgWWg2QI+3D+9Rn4Z/ViitQ==
+  dependencies:
+    fs-extra "^8.0.1"
+    jsonfile "^5.0.0"
+    twemoji-parser "12.1.0"
+    universalify "^0.1.2"
+
 type-fest@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
@@ -6773,7 +6797,7 @@ unique-slug@^2.0.0:
   dependencies:
     imurmurhash "^0.1.4"
 
-universalify@^0.1.0:
+universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==


### PR DESCRIPTION
### This PR adds very basic emoji support. Right now, it only supports emoji codes. 

#### Example:
``:tada:`` becomes :tada:

#### I implemented Twemoji for two reasons:
- it's the same emoji library that Discord is using
- so that everybody has the same emojis (because each OS has different emojis)

#### Demonstration:

![2019-10-19_21-18-10](https://user-images.githubusercontent.com/26326692/67153375-0e560980-f2b6-11e9-8ba4-e92763b25e9e.gif)


#### Future:
The next steps would be to maybe implement some sort of emoji picker and emoji suggestions.

#### Huge thanks to @OatmealDome for helping me out

Closes #21.