### PR TITLE
Fix landing page video autoplay

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@
             </div>
         </div>
         <div class="right" v-if=hasLandingVideo>
-            <iframe class="video" width="1920" height="1080" :src="`https://www.youtube.com/embed/${brand.landing_video_id}?controls=0&autoplay=1&loop=1&playlist=${brand.landing_video_id}`" frameborder="0" allow="accelerometer; autoplay; loop; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+            <iframe class="video" width="1920" height="1080" :src="`https://www.youtube.com/embed/${brand.landing_video_id}?controls=0&autoplay=1&loop=1&mute=1&playlist=${brand.landing_video_id}`" frameborder="0" allow="accelerometer; autoplay; loop; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
     </div>
 </template>


### PR DESCRIPTION
Currently the landing page video does not autoplay on many modern browsers due to the [autoplay policy changes](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes) first introduced in Chrome. This is a tiny fix to ensure that the video on the landing page plays automatically.