### PR TITLE
SPA/static support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ typings/
 
 # nuxt.js build output
 .nuxt
+dist
 
 # vuepress build output
 .vuepress/dist

--- a/components/Button/index.vue
+++ b/components/Button/index.vue
@@ -1,8 +1,8 @@
 <template>
     <a class="is-wrapper" :href=href>
         <button class="button" :class="{ 'has-theme': theme, 'is-discord-theme': theme === 'discord', 'has-icon': icon, 'is-loading': loading, 'is-disabled': disabled }">
-            <img v-if=icon class="icon" :src=icon />
-            <img v-if="icon && hoverIcon" class="icon is-hover" :src=hoverIcon />
+            <img v-if=icon class="icon" :src=icon :alt=iconAlt />
+            <img v-if="icon && hoverIcon" class="icon is-hover" :src=hoverIcon :alt=iconAlt />
             <slot />
         </button>
     </a>
@@ -12,9 +12,10 @@
         props: [
             'href',
             'icon',
-			'hoverIcon',
-			
-			'theme',
+            'hoverIcon',
+            'iconAlt',
+
+            'theme',
 
             'loading',
             'disabled'

--- a/components/Footer/index.vue
+++ b/components/Footer/index.vue
@@ -3,7 +3,7 @@
         <p class="footer">
             &copy; {{ new Date().getFullYear() }} {{ brand.name }}
             <span v-for="page in pages" :key=page.name>
-                &mdash; <a :href=page.link target="_blank">{{ page.name }}</a>
+                &mdash; <a :href=page.link target="_blank" rel="noopener">{{ page.name }}</a>
             </span>
         </p>
     </div>

--- a/components/Header/Menu/RoomMenu.vue
+++ b/components/Header/Menu/RoomMenu.vue
@@ -19,10 +19,10 @@
                 {{ refreshingInvite ? 'Refreshing...' : refreshInviteTooltip }}
             </MenuOption>
         </MenuSection>
-        <MenuOption v-if="room.portal.status === 'open'" name="restartPortal" icon="cube" :loading=restartingPortal :disabled=restartingPortal>
+        <MenuOption v-if="room.portal.status === 'open' && isRoomOwner" name="restartPortal" icon="cube" :loading=restartingPortal :disabled=restartingPortal>
             {{ restartingPortal ? 'Restarting...' : 'Restart Browser' }}
         </MenuOption>
-        <MenuOption name="destroyRoom" icon="circle-close" :loading=destroyingRoom :disabled="refreshingInvite || destroyingRoom">
+        <MenuOption v-if=isRoomOwner name="destroyRoom" icon="circle-close" :loading=destroyingRoom :disabled="refreshingInvite || destroyingRoom">
             {{ destroyingRoom ? 'Deleting...' : 'Delete Room' }}
         </MenuOption>
     </Menu>
@@ -36,7 +36,12 @@
 
     export default {
         computed: {
-            ...mapGetters(['room'])
+            ...mapGetters(['room', 'user']),
+            isRoomOwner() {
+                if (!this.user || !this.room) return false
+
+                return (this.user.id === (typeof this.room.owner === 'string' ? this.room.owner : this.room.owner.id))
+            }
         },
         components: {
             Menu,

--- a/components/Header/Menu/UserMenu.vue
+++ b/components/Header/Menu/UserMenu.vue
@@ -111,14 +111,20 @@
             didClickOption(name) {
                 if (!name) return this.$refs.menu.toggleMenu()
 
-                if (name === 'reload-profile')
-                    this.reloadProfile()
-                else if (name === 'leave-room')
-                    this.leaveRoom()
-                else if (name === 'invite-friends')
-                    this.inviteFriends()
-                else if (name === 'logout')
-                    this.logout()
+                switch(name) {
+                    case 'reload-profile':
+                        this.reloadProfile()
+                        break
+                    case 'leave-room':
+                        this.leaveRoom()
+                        break
+                    case 'invite-friends':
+                        this.inviteFriends()
+                        break
+                    case 'logout':
+                        this.logout()
+                        break
+                }
             }
         }
     }

--- a/components/Header/index.vue
+++ b/components/Header/index.vue
@@ -70,7 +70,7 @@
                 if (!this.user || !this.room) return false
 
                 // return (this.$route.name === 'room')
-                return (this.user.id === (typeof this.room.owner === 'string' ? this.room.owner : this.room.owner.id))
+                return (this.$route.name === 'room' && this.user.id === (typeof this.room.owner === 'string' ? this.room.owner : this.room.owner.id))
             }
         },
         mounted() {

--- a/components/Header/index.vue
+++ b/components/Header/index.vue
@@ -67,11 +67,10 @@
                 return this.$refs.roomMenu.$children[0].visible
             },
             shouldShowRoomMenu() {
-                if (!this.user) return false
-                if (!this.room) return false
+                if (!this.user || !this.room) return false
 
-                return (this.user.id === (typeof this.room.owner === 'string' ? this.room.owner : this.room.owner.id)
-                        && this.$route.name === 'room')
+                // return (this.$route.name === 'room')
+                return (this.user.id === (typeof this.room.owner === 'string' ? this.room.owner : this.room.owner.id))
             }
         },
         mounted() {

--- a/components/Header/index.vue
+++ b/components/Header/index.vue
@@ -53,6 +53,7 @@
             userIcon() {
                 if (!this.user) return null
 
+                // ToDo: Re-work how animated avatars work.
                 return this.user.icon.replace('.gif', '.png')
             },
 
@@ -69,7 +70,6 @@
             shouldShowRoomMenu() {
                 if (!this.user || !this.room) return false
 
-                // return (this.$route.name === 'room')
                 return (this.$route.name === 'room' && this.user.id === (typeof this.room.owner === 'string' ? this.room.owner : this.room.owner.id))
             }
         },
@@ -90,7 +90,6 @@
                     this.toggleRoomMenu(false)
 
                 this.$refs.userMenu.$children[0].toggleMenu()
-                // this.$router.push(this.isUserMenuVisible ? '#user-menu' : '')
             },
             toggleRoomMenu(userAction) {
                 if (!this.isRoomMenuVisible && this.isUserMenuVisible && userAction)
@@ -99,7 +98,6 @@
                 if (!this.shouldShowRoomMenu) return
 
                 this.$refs.roomMenu.$children[0].toggleMenu()
-                // this.$router.push(this.isRoomMenuVisible ? '#room-menu' : '')
             }
         }
     }

--- a/components/Invite/Room/Hint.vue
+++ b/components/Invite/Room/Hint.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="invite-hint">
+    <div v-if=inviteLink class="invite-hint">
         <h3 class="invite-hint-title">
             Rooms are better with friends
         </h3>
@@ -28,6 +28,8 @@
             ...mapGetters(['room']),
 
             inviteLink() {
+                if (!this.room) return
+
                 return `${process.env.BASE_WEB_URL}/i/${this.room.invites[0].code}`
             }
         },

--- a/components/Loading/index.html
+++ b/components/Loading/index.html
@@ -1,0 +1,31 @@
+<div class="content is-center">
+    <div class="gradient is-loading" id="loading-logo"></div>
+</div>
+
+<script type="text/javascript">
+    window.addEventListener('error', function () {
+        var e = document.getElementById('loading-logo');
+        if (e)
+            e.className = 'gradient is-error'
+    });
+</script>
+
+<style type="text/css">
+    div.gradient {
+        width: 150px;
+        height: 150px;
+
+        mask-repeat: round;
+        -webkit-mask-repeat: round;
+        mask-image: url('/img/logo-light.svg');
+        -webkit-mask-image: url('/img/logo-light.svg');
+
+        opacity: 1;
+
+        transition: all 0.2s
+    }
+
+    div.is-error {
+        background: red
+    }
+</style>

--- a/components/Player/Viewer.vue
+++ b/components/Player/Viewer.vue
@@ -128,6 +128,7 @@
                 this.player = new JSMpeg.Player(`${this.apertureWs}/?t=${this.apertureToken}`, {
                     canvas: this.$refs.stream,
                     pauseWhenHidden: false,
+                    // ToDo: check if this is /really/ needed
                     videoBufferSize: parseInt(process.env.VIDEO_BITRATE || 1200) * 1024,
                     audioBufferSize: parseInt(process.env.AUDIO_BITRATE || 128) * 1024,
                     // workarounds so jsmpeg breaks less

--- a/components/Player/Viewer.vue
+++ b/components/Player/Viewer.vue
@@ -60,12 +60,14 @@
             },
 
             streamWidth() {
-                if (!this.player) return 1280
+                if (!this.player)
+                    return 1280
 
                 return this.player.video.destination.width
             },
             streamHeight() {
-                if (!this.player) return 720
+                if (!this.player)
+                    return 720
 
                 return this.player.video.destination.height
             },
@@ -107,7 +109,8 @@
                 this.$refs.stream.onpaste = this.didPaste
         },
         beforeDestroy() {
-            if (this.player) this.player.destroy()
+            if (this.player)
+                this.player.destroy()
         },
         methods: {
             unmute() {
@@ -115,11 +118,12 @@
             },
 
             playStream() {
-                if (typeof window === 'undefined') return
+                if (typeof window === 'undefined')
+                    return
                 if (!JSMpeg)
                     return this.$nextTick(this.playStream)
-
-                if (this.player) this.player.destroy()
+                if (this.player)
+                    this.player.destroy()
 
                 this.player = new JSMpeg.Player(`${this.apertureWs}/?t=${this.apertureToken}`, {
                     canvas: this.$refs.stream,

--- a/components/Player/Viewer.vue
+++ b/components/Player/Viewer.vue
@@ -221,6 +221,9 @@
 
                 return Math.round(this.streamHeight * (yPos / elem.clientHeight))
             }
+        },
+        beforeDestroy() {
+            if (this.player) this.player.destroy()
         }
     }
 </script>

--- a/components/Player/Viewer.vue
+++ b/components/Player/Viewer.vue
@@ -99,13 +99,15 @@
                 switch(type) {
                     case 'updateAperture':
                         this.$nextTick(this.playStream)
-
                         break
                 }
             })
 
             if (this.$refs.stream)
                 this.$refs.stream.onpaste = this.didPaste
+        },
+        beforeDestroy() {
+            if (this.player) this.player.destroy()
         },
         methods: {
             unmute() {
@@ -114,7 +116,8 @@
 
             playStream() {
                 if (typeof window === 'undefined') return
-                if (!JSMpeg) return // TODO: Add a popup that allows the user to retry playing the stream once the jsmpeg script has loaded
+                if (!JSMpeg)
+                    return this.$nextTick(this.playStream)
 
                 if (this.player) this.player.destroy()
 
@@ -221,9 +224,6 @@
 
                 return Math.round(this.streamHeight * (yPos / elem.clientHeight))
             }
-        },
-        beforeDestroy() {
-            if (this.player) this.player.destroy()
         }
     }
 </script>

--- a/components/Player/index.vue
+++ b/components/Player/index.vue
@@ -29,7 +29,7 @@
                     Hold your rabbits...
                 </h1>
                 <p class="body">
-                    We're waiting for the right gears to align, so we can get your virtual browser ready - hold tight!
+                    We're waiting for the right gears to align, so we can get your browser ready - hold tight!
                     <br>
                     If this is taking a little long, restart the room
                 </p>
@@ -46,7 +46,7 @@
             <!-- The portal is either being created or starting -->
             <div v-else-if="portalStatus === 'creating' || portalStatus === 'starting'" class="player-message">
                 <h1 class="title">
-                    We're {{ portalStatus }} your portal now
+                    We're {{ portalStatus }} your browser now
                 </h1>
                 <p class="body">
                     Normally this takes a couple seconds, hang tight!

--- a/components/Player/index.vue
+++ b/components/Player/index.vue
@@ -13,22 +13,23 @@
                 <br>
                 Portal Status: {{ portalStatus }}
             </p>
-            <!-- Portal is not open and there is only one person in the room -->
+            <!-- Portal is not open and there is only one person in the room
+                 ToDo: change this in case there's a different minimum requirement -->
             <div v-if="(portalStatus === 'waiting' || portalStatus === 'closed') && room.members.length === 1" class="player-message">
                 <h1 class="title">
                     And so it begins...
                 </h1>
                 <p class="body">
-                    Add a friend or two to get the party started! Once someone else joins this room, we'll queue up your room for a virtual browser
+                    Add a friend or two to get the party started! Once someone else joins this room, we'll queue up your room for a portal
                 </p>
             </div>
-            <!-- Portal is not open but there are more than one members in the room -->
+            <!-- Portal is not open but there is more than one member in the room -->
             <div v-else-if="(portalStatus === 'waiting' || portalStatus === 'closed') && room.members.length > 1" class="player-message">
                 <h1 class="title">
                     Hold your rabbits...
                 </h1>
                 <p class="body">
-                    We're waiting for the right gears to align so we can get your browser ready - hold tight!
+                    We're waiting for the right gears to align, so we can get your portal ready - hold tight!
                     <br>
                     If this is taking a little long, restart the room
                 </p>
@@ -39,27 +40,38 @@
                     You're in the queue!
                 </h1>
                 <p class="body">
-                    There are a couple rooms infront of you waiting for a virtual browser, it shouldn't take too long
+                    There are a couple rooms in front of you waiting for a portal, please grab your popcorn!
                 </p>
             </div>
             <!-- The portal is either being created or starting -->
             <div v-else-if="portalStatus === 'creating' || portalStatus === 'starting'" class="player-message">
                 <h1 class="title">
-                    We're {{ portalStatus }} your browser now
+                    We're {{ portalStatus }} your portal now
                 </h1>
                 <p class="body">
                     Normally this takes a couple seconds, hang tight!
                     <br>
-                    If you have any issues either refresh the page or ask the room owner to restart the browser
+                    If you have any issues either refresh the page or ask the room owner to restart the portal
                 </p>
             </div>
-            <!-- The portal is created and the stream between the client and the aperture is being established -->
+            <!-- The portal has been created and the stream between the client and the aperture is being established -->
             <div v-else-if="portalStatus === 'open'" class="player-message">
                 <h1 class="title">
                     Strap in...
                 </h1>
                 <p class="body">
-                    Everything is ready - we're just getting the stream between you and the VM started
+                    Everything is ready - we're just getting the stream between the portal and you started
+                </p>
+            </div>
+            <!-- Something wrong happened while starting the portal -->
+            <div v-else-if="portalStatus === 'error'" class="player-message">
+                <h1 class="title">
+                    Oh, no!
+                </h1>
+                <p class="body">
+                    Something bad happened that isn't letting this instance from starting a portal.
+                    <br>
+                    We'll try to recover, but if this is stuck for too long, restart the room
                 </p>
             </div>
             <div class="loading-wrapper">

--- a/components/Player/index.vue
+++ b/components/Player/index.vue
@@ -20,7 +20,7 @@
                     And so it begins...
                 </h1>
                 <p class="body">
-                    Add a friend or two to get the party started! Once someone else joins this room, we'll queue up your room for a portal
+                    Add a friend or two to get the party started! Once someone else joins this room, we'll queue up your room for a virtual browser
                 </p>
             </div>
             <!-- Portal is not open but there is more than one member in the room -->
@@ -29,7 +29,7 @@
                     Hold your rabbits...
                 </h1>
                 <p class="body">
-                    We're waiting for the right gears to align, so we can get your portal ready - hold tight!
+                    We're waiting for the right gears to align, so we can get your virtual browser ready - hold tight!
                     <br>
                     If this is taking a little long, restart the room
                 </p>
@@ -40,7 +40,7 @@
                     You're in the queue!
                 </h1>
                 <p class="body">
-                    There are a couple rooms in front of you waiting for a portal, please grab your popcorn!
+                    There are a couple rooms in front of you waiting for a virtual browser, please grab your popcorn!
                 </p>
             </div>
             <!-- The portal is either being created or starting -->
@@ -51,7 +51,7 @@
                 <p class="body">
                     Normally this takes a couple seconds, hang tight!
                     <br>
-                    If you have any issues either refresh the page or ask the room owner to restart the portal
+                    If you have any issues either refresh the page or ask the room owner to restart the browser
                 </p>
             </div>
             <!-- The portal has been created and the stream between the client and the aperture is being established -->
@@ -60,7 +60,7 @@
                     Strap in...
                 </h1>
                 <p class="body">
-                    Everything is ready - we're just getting the stream between the portal and you started
+                    Everything is ready - we're just getting the stream between the browser and you started
                 </p>
             </div>
             <!-- Something wrong happened while starting the portal -->
@@ -69,7 +69,7 @@
                     Oh, no!
                 </h1>
                 <p class="body">
-                    Something bad happened that isn't letting this instance from starting a portal.
+                    Something bad happened that isn't letting this instance from starting a virtual browser.
                     <br>
                     We'll try to recover, but if this is stuck for too long, restart the room
                 </p>

--- a/components/Player/index.vue
+++ b/components/Player/index.vue
@@ -101,10 +101,16 @@
             },
 
             portalStatus() {
+                if (!this.portal)
+                    return 'closed'
+
                 return this.portal.status
             },
 
             isSelfRoomOwner() {
+                if (!this.room)
+                    return false
+
                 return this.room.owner.id === this.user.id
             }
         }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,13 +9,11 @@
     </div>
 </template>
 <script>
-    import { mapGetters } from 'vuex'
-
     import brand from '~/brand/config'
 
     import Header from '~/components/Header'
 	import Footer from '~/components/Footer'
-	
+
     import GoogleAnalytics from '~/components/GoogleAnalytics'
 
     export default {
@@ -30,33 +28,11 @@
             }
         },
         head() {
-            const script = []
-
-            if (this.brand.ga_tracking_id)
-                script.push({
-                    src: `https://www.googletagmanager.com/gtag/js?id=${this.brand.ga_tracking_id}`
-                })
-
             return {
-                titleTemplate: chunk => this.$route.name === 'room' && this.room ? `${this.room.name} - ${this.brand.name}` : (chunk ? `${chunk} - ${this.brand.name}` : this.brand.name),
-                meta: [
-                    { charset: 'utf-8' },
-                    { name: 'viewport', content: 'width=device-width, initial-scale=1, user-scalable=no' },
-                    { name: 'description', content: `${this.brand.name} makes it easy to enjoy what you love with your friends` },
-                    { name: 'theme-color', content: '#000000' },
-                    { property: 'og:image', content: '/img/icon-hq.png'}
-                ],
-                link: [
-                    { rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }
-                ],
-                script: [
-                    ...script
-                ]
+                titleTemplate: chunk => (chunk ? `${chunk} - ${this.brand.name}` : this.brand.name)
             }
         },
         computed: {
-            ...mapGetters(['room']),
-
             isRoomPage() {
                 return this.$route.name === 'room'
             }

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -7,10 +7,13 @@
             Fuck.
         </h1>
         <p v-if="error.statusCode === 404" class="subtitle">
-            We couldn't find this page. Maybe it's our fault, maybe it's yours, but you should <nuxt-link to="/home">go home</nuxt-link> in any case.
+            We couldn't find this page. Maybe it's our fault, maybe it's yours.
         </p>
-        <p v-else>
-            We're not sure what quite happened here. It's our fault, so for now you should <nuxt-link to="/home">go home</nuxt-link> now.
+        <p v-else class="subtitle">
+            We're not quite sure what happened here, but it's definitely our fault.
+        </p>
+        <p class="disclaimer">
+            You might want to <nuxt-link to="/home">go home</nuxt-link> now.
         </p>
     </div>
 </template>

--- a/layouts/logged-out.vue
+++ b/layouts/logged-out.vue
@@ -13,29 +13,6 @@
         components: {
             GoogleAnalytics
         },
-        head() {
-            const script = []
-
-            if (this.brand.ga_tracking_id)
-                script.push({
-                    src: `https://www.googletagmanager.com/gtag/js?id=${this.brand.ga_tracking_id}`
-                })
-
-            return {
-                titleTemplate: this.brand.name,
-                meta: [
-                    { charset: 'utf-8' },
-                    { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-                    { name: 'description', content: `${this.brand.name} makes it easy to enjoy what you love with your friends` }
-                ],
-                link: [
-                    { rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }
-                ],
-                script: [
-                    ...script
-                ]
-            }
-        },
         data() {
             return {
                 brand

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,14 +1,21 @@
-require('dotenv').config()
+import 'dotenv/config'
+import brand from './brand/config'
 
 const borealis = process.env.BOREALIS_REPOSITORY && process.env.NODE_ENV === 'development' ? process.env.BOREALIS_REPOSITORY : '@cryb/borealis'
 
-export default {
-    loading: false,
-    modules: [
-        'nuxt-client-init-module',
-        'nuxt-clipboard2',
+const script = []
+if (brand.ga_tracking_id)
+    script.push({
+        src: `https://www.googletagmanager.com/gtag/js?id=${brand.ga_tracking_id}`,
+        async: true,
+        defer: true
+    })
 
-        '@nuxtjs/axios'
+export default {
+    globalName: 'cryb',
+    mode: 'spa',
+    css: [
+        borealis
     ],
     env: {
         /**
@@ -31,6 +38,19 @@ export default {
         AUDIO_BITRATE: process.env.AUDIO_BITRATE,
         VIDEO_BITRATE: process.env.VIDEO_BITRATE
     },
+    generate: {
+        routes: [
+            '/i/'
+        ]
+    },
+    modules: [
+        'nuxt-client-init-module',
+        'nuxt-clipboard2',
+
+        '@nuxtjs/axios',
+        '@nuxtjs/robots'
+    ],
+
     axios: {
         baseURL: process.env.API_BASE_URL
     },
@@ -38,7 +58,29 @@ export default {
         extractCSS: true,
         publicPath: (process.env.PUBLIC_PATH || '/_cryb/')
 	},
-	css: [
-		borealis
-	]
+    head: {
+        title: brand.name,
+        meta: [
+            { charset: 'utf-8' },
+            { name: 'viewport', content: 'width=device-width, initial-scale=1, user-scalable=no' },
+            { name: 'description', content: `${brand.name} makes it easy to enjoy what you love with your friends` },
+            { name: 'theme-color', content: '#000000' },
+            { property: 'og:title', content: brand.name },
+            { property: 'og:image', content: '/img/icon-hq.png' },
+            { property: 'og:type', content: 'website' }
+        ],
+        link: [
+            { rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }
+        ],
+        script: [
+            ...script
+        ]
+    },
+    loadingIndicator: '~/components/Loading/index.html',
+    robots: {
+        // by default, this only allows the root to be indexed, not the rest, which is enough.
+        UserAgent: '*',
+        Allow: '/$',
+        Disallow: '/'
+    }
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   "scripts": {
     "start": "nuxt start",
     "build": "nuxt build",
+    "generate": "nuxt generate",
     "dev": "nuxt",
     "lint": "eslint ."
   },
   "dependencies": {
     "@cryb/borealis": "^1.0.3",
     "@nuxtjs/axios": "^5.5.4",
+    "@nuxtjs/robots": "^2.4.2",
     "browser-cookies": "^1.2.0",
     "cookieparser": "^0.1.0",
     "date-fns": "^2.5.1",

--- a/pages/auth/discord.vue
+++ b/pages/auth/discord.vue
@@ -5,11 +5,6 @@
 </template>
 <script>
 export default {
-    head() {
-        return {
-            title: 'Logging in'
-        }
-    },
     middleware: 'logged-out',
     data() {
         return {
@@ -29,6 +24,11 @@ export default {
             setTimeout(() => this.$router.push(state ? `/i/${state.split('=')[1]}` : '/home'), 250)
         } catch(error) {
             this.message = 'An error occurred while authenticating. Please go home and try logging in again.'
+        }
+    },
+    head() {
+        return {
+            title: 'Logging in'
         }
     }
 }

--- a/pages/home.vue
+++ b/pages/home.vue
@@ -16,9 +16,6 @@
                         <h3 class="header">
                             Return to {{ room.name }}
                         </h3>
-                        <!-- <p class="description">
-							Received an invite link or an invite code for a room? Enter it here!
-						</p> -->
                     </div>
                 </nuxt-link>
                 <nuxt-link class="is-wrapper" to="#leave-room" @click.native=leaveRoom()>
@@ -27,9 +24,6 @@
                         <h3 class="header">
                             {{ leavingRoom ? 'Leaving' : 'Leave' }} {{ room.name }}{{ leavingRoom ? '...' : '' }}
                         </h3>
-                        <!-- <p class="description">
-							Need a room where you can watch anything with your friends? This is the place to go
-						</p> -->
                     </div>
                 </nuxt-link>
             </div>
@@ -72,25 +66,12 @@
     import { mapGetters } from 'vuex'
 
     export default {
+        middleware: 'authenticated',
         data() {
             return {
                 leavingRoom: false
             }
         },
-        head() {
-            return {
-                title: (
-                    this.isCreateRoomModalVisible ?
-                    'Create a Room' :
-                    (
-                        this.isJoinRoomModalVisible ?
-                        'Join a Room' :
-                        null
-                    )
-                )
-            }
-        },
-        middleware: 'authenticated',
         computed: {
             ...mapGetters(['user']),
             room() {
@@ -137,6 +118,19 @@
 
                 this.$refs.createRoomModal.visible = false
                 this.$refs.joinRoomModal.visible = false
+            }
+        },
+        head() {
+            return {
+                title: (
+                    this.isCreateRoomModalVisible ?
+                        'Create a Room' :
+                        (
+                            this.isJoinRoomModalVisible ?
+                                'Join a Room' :
+                                null
+                        )
+                )
             }
         }
     }

--- a/pages/i/_id.vue
+++ b/pages/i/_id.vue
@@ -26,14 +26,11 @@
             <Button v-else-if=redirectUrl theme="discord" :href=redirectUrl icon="/icons/discord-white.svg" hover-icon="/icons/discord-colour.svg">
                 Login with Discord
             </Button>
-            <p v-if=reqFailed class="disclaimer">
-                Looks like an issue occured while trying to contact
-            </p>
-            <p v-else-if=!redirectUrl class="disclaimer">
+            <p v-if=!redirectUrl class="disclaimer">
                 Uh-oh! Looks like we can't find a redirect URL for Login with Discord.
             </p>
             <p v-else-if="token && !user" class="disclaimer">
-                Please wait...
+                An error has occurred while trying to authenticate with this instance's API
             </p>
 
             <p v-if="isSelfInRoom && !isSelfInInvitedRoom" class="disclaimer">
@@ -56,9 +53,7 @@
             We couldn't find a room linked with this invite code. Make sure you have the right invite and try again!
         </p>
         <p class="disclaimer">
-            You might want to <nuxt-link to="/home">
-                go home
-            </nuxt-link> now.
+            You might want to <nuxt-link to="/home">go home</nuxt-link> now.
         </p>
     </div>
 </template>
@@ -93,9 +88,6 @@
 
                         { property: 'og:title', content: `Join ${this.room.name} on ${this.brand.name}` },
                         { property: 'og:description', content: `You've been invted to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
-                    ],
-                    link: [
-                        { rel: 'icon', type: 'image/x-icon', href: '/favicon.png' }
                     ]
                 }
 
@@ -123,20 +115,6 @@
 
                 return this.user.room && this.user.room.id === this.room.id
             }
-        },
-        async mounted() {
-            if (this.token && !this.user)
-                try {
-                    await this.$axios.$get('user/me')
-                    // fetch user if it worked
-                    // ToDo: avoid doing 2 requests for this
-                    this.$store.dispatch('fetchUser')
-                } catch(error) {
-                    if (error.response && error.response.data.response === 'USER_NO_AUTH')
-                        this.$store.commit('logout')
-                    else
-                        this.reqFailed = true
-                }
         },
         async asyncData(context) {
             try {

--- a/pages/i/_id.vue
+++ b/pages/i/_id.vue
@@ -124,20 +124,20 @@
                 return this.user.room && this.user.room.id === this.room.id
             }
         },
-        // async mounted() {
-        //     if (this.token && !this.user)
-		// 		try {
-		// 			await this.$axios.$get('user/me')
-		// 			// fetch user if it worked
-		// 			// ToDo: avoid doing 2 requests for this
-		// 			this.$store.dispatch('fetchUser')
-		// 		} catch(error) {
-		// 			if (error.response && error.response.data.response === 'USER_NO_AUTH')
-		// 				this.$store.commit('logout')
-		// 			else
-		// 				this.reqFailed = true
-		// 		}
-        // },
+        async mounted() {
+            if (this.token && !this.user)
+                try {
+                    await this.$axios.$get('user/me')
+                    // fetch user if it worked
+                    // ToDo: avoid doing 2 requests for this
+                    this.$store.dispatch('fetchUser')
+                } catch(error) {
+                    if (error.response && error.response.data.response === 'USER_NO_AUTH')
+                        this.$store.commit('logout')
+                    else
+                        this.reqFailed = true
+                }
+        },
         async asyncData(context) {
             try {
                 const redirectUrl = await context.$axios.$get(`/auth/discord/redirect?invite=${context.route.params.id}`),

--- a/pages/i/_id.vue
+++ b/pages/i/_id.vue
@@ -62,13 +62,22 @@
 
     import brand from '~/brand/config'
 
-    import Form from '~/components/Form'
     import Button from '~/components/Button'
 
     export default {
         components: {
-            Form,
             Button
+        },
+        async asyncData(context) {
+            try {
+                const redirectUrl = await context.$axios.$get(`/auth/discord/redirect?invite=${context.route.params.id}`),
+                    room = await context.$axios.$get(`/invite/${context.route.params.id}/peek`)
+
+                return { room, redirectUrl }
+            } catch(error) {
+                console.error(error)
+                return { room: null, redirectUrl: null }
+            }
         },
         data() {
             return {
@@ -76,24 +85,6 @@
                 error: '',
                 loading: false,
                 reqFailed: false
-            }
-        },
-        head() {
-            let inviteHeaders = {}
-
-            if (this.room)
-                inviteHeaders = {
-                    meta: [
-                        { name: 'description', content: `You've been invited to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
-
-                        { property: 'og:title', content: `Join ${this.room.name} on ${this.brand.name}` },
-                        { property: 'og:description', content: `You've been invted to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
-                    ]
-                }
-
-            return {
-                title: this.room ? `Join ${this.room.name}` : 'Invite Not Found',
-                ...inviteHeaders
             }
         },
         computed: {
@@ -114,17 +105,6 @@
                 if (!this.user) return false
 
                 return this.user.room && this.user.room.id === this.room.id
-            }
-        },
-        async asyncData(context) {
-            try {
-                const redirectUrl = await context.$axios.$get(`/auth/discord/redirect?invite=${context.route.params.id}`),
-                    room = await context.$axios.$get(`/invite/${context.route.params.id}/peek`)
-
-                return { room, redirectUrl }
-            } catch(error) {
-                console.error(error)
-                return { room: null, redirectUrl: null }
             }
         },
         methods: {
@@ -148,6 +128,24 @@
 
                 this.$store.dispatch('leaveRoom')
             }
-        }
+        },
+        head() {
+            let inviteHeaders = {}
+
+            if (this.room)
+                inviteHeaders = {
+                    meta: [
+                        { name: 'description', content: `You've been invited to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
+
+                        { property: 'og:title', content: `Join ${this.room.name} on ${this.brand.name}` },
+                        { property: 'og:description', content: `You've been invted to join ${this.membersList} on ${this.brand.name}, the best way to share the internet with your friends` },
+                    ]
+                }
+
+            return {
+                title: this.room ? `Join ${this.room.name}` : 'Invite Not Found',
+                ...inviteHeaders
+            }
+        },
     }
 </script>

--- a/pages/room/create.vue
+++ b/pages/room/create.vue
@@ -5,14 +5,14 @@
     import CreateRoom from '~/components/Room/Create'
 
     export default {
+        middleware: 'authenticated',
+        components: {
+            CreateRoom
+        },
         head() {
             return {
                 title: 'Create a Room'
             }
-        },
-        middleware: 'authenticated',
-        components: {
-            CreateRoom
         }
     }
 </script>

--- a/pages/room/index.vue
+++ b/pages/room/index.vue
@@ -22,14 +22,6 @@
     import PlayerFooter from '~/components/Player/Footer'
 
     export default {
-        head() {
-            return {
-                title: this.error ? 'Room Not Found' : (this.room ? this.room.name : ''),
-                script: [
-                    { src: '/js/jsmpeg.min.js' }
-                ]
-            }
-        },
         middleware: 'authenticated',
         components: {
             Chat,
@@ -51,6 +43,14 @@
         },
         beforeDestroy() {
             this.$store.commit('disconnectWebSocket')
+        },
+        head() {
+            return {
+                title: this.error ? 'Room Not Found' : (this.room ? this.room.name : ''),
+                script: [
+                    { src: '/js/jsmpeg.min.js' }
+                ]
+            }
         }
     }
 </script>

--- a/pages/room/join.vue
+++ b/pages/room/join.vue
@@ -5,14 +5,14 @@
     import JoinRoom from '~/components/Room/Join'
 
     export default {
+        middleware: 'authenticated',
+        components: {
+            JoinRoom
+        },
         head() {
             return {
                 title: 'Join a Room'
             }
-        },
-        middleware: 'authenticated',
-        components: {
-            JoinRoom
         }
     }
 </script>

--- a/store/index.js
+++ b/store/index.js
@@ -304,11 +304,11 @@ export const mutations = {
         */
     allowCookies(state, { save } = { save: true }) {
         if (save && process.client)
-                cookies.set('cookies', '1', {
-                    expires: 365 * 10, // 10 years
-                    domain: process.env.COOKIE_DOMAIN,
-                    secure: isProduction()
-                })
+            cookies.set('cookies', '1', {
+                expires: 365 * 10, // 10 years
+                domain: process.env.COOKIE_DOMAIN,
+                secure: isProduction()
+            })
     },
 
     /**

--- a/store/index.js
+++ b/store/index.js
@@ -96,18 +96,16 @@ export const mutations = {
 
         this.$axios.setHeader('authorization', `Bearer ${token}`)
 
-        if (!process.server)
-            if (save)
-                if (token)
-                    cookies.set('token', token, {
-                        expires: 365,
-                        domain: process.env.COOKIE_DOMAIN,
-                        secure: isProduction()
-                    })
-                else
-                    cookies.erase('token', {
-                        domain: process.env.COOKIE_DOMAIN
-                    })
+        if (token && save && process.client)
+            cookies.set('token', token, {
+                expires: 365,
+                domain: process.env.COOKIE_DOMAIN,
+                secure: isProduction()
+            })
+        else if (save && process.client)
+            cookies.erase('token', {
+                domain: process.env.COOKIE_DOMAIN
+            })
     },
 
     /**
@@ -305,8 +303,7 @@ export const mutations = {
      * Cookies
         */
     allowCookies(state, { save } = { save: true }) {
-        if (!process.server)
-            if (save)
+        if (save && process.client)
                 cookies.set('cookies', '1', {
                     expires: 365 * 10, // 10 years
                     domain: process.env.COOKIE_DOMAIN,
@@ -464,7 +461,7 @@ export const mutations = {
             0
         )
 
-        if (!process.server)
+        if (process.client)
             cookies.erase('token', {
                 domain: process.env.COOKIE_DOMAIN
             })
@@ -545,7 +542,6 @@ export const actions = {
 
         if (token) {
             commit('handleToken', { token, save: false })
-            // fetch user if we haven't got it (SPA/static or API error)
             if (!this.user)
                await this.dispatch('fetchUser')
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@
     consola "^2.5.6"
     http-proxy-middleware "^0.19.1"
 
+"@nuxtjs/robots@^2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/robots/-/robots-2.4.2.tgz#9a96c91abb70e39b414eec502ef1cf7d5ef0235e"
+  integrity sha512-BW3qhvxlPBKlMkZHtARFPeliFraiZHS28G3j4qgRbSfOBtHC0yDX3Dnq1LkQMzAbPfbw6A1L3sdjgBVZZnfFAw==
+
 "@nuxtjs/youch@^4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@nuxtjs/youch/-/youch-4.2.3.tgz#36f8b22df5a0efaa81373109851e1d857aca6bed"


### PR DESCRIPTION
This changes how `@cryb/web` rendering works. As of now, it has been done using Server-Side Rendering, and since we have seen that switching to Single Page Application rendering won't hurt but more than enhance things performance-side and preventing some issues, while even allowing to host this as a static page, this will be the default from now on.

* Page actually works as it should! (No need to re-login each visit)
* Has a loading animation (ToDo: @neoncloth move styles to `@cryb/borealis` [which is more likely to be safe to do since styles are pre-fetched] _and_ fix centering when on mobile.)
* Fetches user correctly, and redirects to `/` if it can't (as it was doing before, but now reworked to not repeat code)
* SSR still works, simple as commenting the `mode: 'spa'` line in `nuxt.config.js` to enable it back (possibly making this configurable in the future?)
* Can also use `yarn generate` to generate a static site, which works completely (Note: Requires rewriting rules for invites to work so it fetches `/i/index.html`, since those are dynamic and will 404)

Plus this, includes a few changes that I was doing before:
* Add robots.txt support (blocking everything except `/`, which is the only one that needs to be indexed)
* Few messages, styling and other minor changes

~~Seems to work fine~~ Forgot to fix [this](https://cdn.discordapp.com/attachments/622934150051004426/668759175987462164/Screenshot_20200120-060943.png), but other than that it works, but extra testing is appreciated.

I'm also thinking of changing some other things, but that'd be for later changes.